### PR TITLE
simplify _matchNode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import {defineRule, definePatternRule, canApplyRule, applyRule} from './lib/matcher'
+import {defineRule, definePatternRule, canApplyRule, applyRule} from './lib/rule'
 import {flattenOperands} from './lib/utils'
-import * as rules from './lib/rules.js'
+import * as rules from './lib/rule-list.js'
 
 export {
     applyRule,

--- a/lib/__test__/matcher.test.js
+++ b/lib/__test__/matcher.test.js
@@ -2,43 +2,16 @@ import assert from 'assert'
 import {parse, print} from 'math-parser'
 import {build, query} from 'math-nodes'
 
-import {
-    matchNode,
-    match,
-    defineRule,
-    definePatternRule,
-    canApplyRule,
-    applyRule,
-    populatePattern,
-    patternToMatchFn,
-} from '../matcher'
-
+import {matchNode, match} from '../matcher'
+import {patternToMatchFn} from '../pattern'
 import {isVariableFactor} from '../rules/collect-like-terms'
 
-// returns the rewritten string
-const rewriteString = (matchPattern, rewritePattern, input) => {
-    const rule = defineRuleString(matchPattern, rewritePattern)
-    const ast = applyRule(rule, parse(input))
-    return print(ast)
-}
 
 // returns the matched node in the AST of the parsed input
 const matchString = (pattern, input) => {
     const matchFn = patternToMatchFn(parse(pattern))
     return match(matchFn, parse(input))
 }
-
-const defineRuleString = (matchPattern, rewritePattern, constraints) =>
-    definePatternRule(parse(matchPattern), parse(rewritePattern), constraints)
-
-const canApplyRuleString = (rule, input) => canApplyRule(rule, parse(input))
-
-const applyRuleString = (rule, input) => print(applyRule(rule, parse(input)))
-
-const populatePatternString = (pattern, placeholders) => populatePattern(parse(pattern), placeholders)
-
-const isFunction = (val) => typeof val === 'function'
-
 
 describe('matcher', () => {
     describe('matchNode', () => {
@@ -99,125 +72,6 @@ describe('matcher', () => {
             assert(matchString('#a x', '3 x'))
             assert(matchString('#a x + #b x', '3 x + 5 x'))
             assert.equal(matchString('#a x + #b x', '3 x + 5 y'), null)
-        })
-    })
-
-    describe('rewrite', () => {
-        it('should replace x + 0', () => {
-            const result = rewriteString('#a + 0', '#a', '2 * (x + 0)')
-            assert.equal(result, '2 * x')
-        })
-
-        it('should replace x + 0 as a subexpression', () => {
-            const result = rewriteString('#a + 0', '#a', '2 * (x + 0)')
-            assert.equal(result, '2 * x')
-        })
-
-        it('should replace the innermost x + 0', () => {
-            const result = rewriteString('#a + 0', '#a', '(x + 0) + 0')
-            assert.equal(result, 'x + 0')
-        })
-
-        it('should replace x + 0 within a large expression', () => {
-            const result = rewriteString('#a + 0', '#a', '1 + x + 0 + 2')
-            assert.equal(result, '1 + x + 2')
-        })
-
-        it('should replace an single node with an add operation', () => {
-            const result = rewriteString('2 #a', '#a + #a', '1 + 2 x + 2')
-            assert.equal(result, '1 + (x + x) + 2')
-        })
-
-        it('should replace an single node with a mul operation', () => {
-            const result = rewriteString('2 #a', '#a + #a', '1 * 2 x * 3')
-            assert.equal(result, '1 * (x + x) * 3')
-        })
-
-        it('should work from the inside out', () => {
-            const result = rewriteString('#a + 0', '#a', '((x + 0) + 0) + 0')
-            assert.equal(result, '(x + 0) + 0')
-        })
-
-        it('should apply the rule a single time', () => {
-            const result = rewriteString('#a + 0', '#a', '(x + 0) + (x + 0)')
-            assert.equal(result, 'x + (x + 0)')
-
-            const result2 = rewriteString('#a + 0', '#a', 'x + 0 + x + 0')
-            assert.equal(result2, 'x + x + 0')
-        })
-    })
-
-    describe('canApplyRule', () => {
-        it('should accept applicable rules', () => {
-            const rule = defineRuleString('#a + #a', '2 #a')
-            assert(canApplyRuleString(rule, 'x + x'))
-        })
-
-        it('should reject unapplicable rules', () => {
-            const rule = defineRuleString('#a + #a', '2 #a')
-            assert.equal(canApplyRuleString(rule, 'x + y'), false)
-        })
-
-        it('should accept applicable rules based on constraints', () => {
-            const rule = defineRuleString('#a + #a', '2 * #a', { a: query.isNumber })
-            assert(canApplyRuleString(rule, '3 + 3'))
-        })
-
-        it('should reject unapplicable rules based on constraints', () => {
-            const rule = defineRuleString('#a + #a', '2 #a', { a: query.isNumber })
-            assert.equal(canApplyRuleString(rule, 'x + x'), false)
-        })
-    })
-
-    describe('applyRule', () => {
-        it('should apply applicable rules', () => {
-            const rule = defineRuleString('#a + #a', '2 #a')
-            assert.equal(applyRuleString(rule, 'x + x'), '2 x')
-        })
-
-        it('should apply applicable rules based on constraints', () => {
-            const rule = defineRuleString('#a #x + #b #x', '(#a + #b) #x', {
-                a: query.isNumber,
-                b: query.isNumber,
-            })
-            assert.equal(applyRuleString(rule, '2 x + 3 x'), '(2 + 3) x')
-            assert.equal(canApplyRuleString(rule, '(a + b) x'), false)
-        })
-
-        it('should apply rules with a rewrite callback', () => {
-            const rule = defineRule(
-                patternToMatchFn(parse('#a #b'), {b: query.isAdd}),
-                (_, {a, b}) => build.applyNode(
-                    'add',
-                    b.args.map(arg => populatePatternString('#a #arg', {a, arg}))
-                ),
-                {b: query.isAdd})
-
-            assert.equal(
-                applyRuleString(rule, '3 (x + 1)'),
-                '3 x + 3 1')
-
-            assert.equal(
-                applyRuleString(rule, '(a - b) (x^2 + 2x + 1)'),
-                '(a - b) x^2 + (a - b) (2 x) + (a - b) 1')
-        })
-
-        it('should evaluate sums of numbers', () => {
-            const rule = defineRule(
-                patternToMatchFn(parse('#a'), {
-                    a: (a) => query.isAdd(a) && a.args.every(query.isNumber)
-                }),
-                // TODO: use evaluate from node-parser
-                // TODO: add a special 'eval' node so that we do '#eval(#a)'
-                (_, {a}) => build.numberNode(
-                    a.args.reduce((total, arg) => total + query.getValue(arg), 0)),
-                {
-                    a: (a) => query.isAdd(a) && a.args.every(query.isNumber)
-                },
-            )
-
-            assert.equal(applyRuleString(rule, '(1 - 2 + 3) x'), '2 x')
-            assert.equal(applyRuleString(rule, '(1 + 2 + 3) x'), '6 x')
         })
     })
 

--- a/lib/__test__/rule-list.test.js
+++ b/lib/__test__/rule-list.test.js
@@ -1,8 +1,8 @@
 import assert from 'assert'
 import {parse, print, evaluate} from 'math-parser'
 
-import {applyRule, canApplyRule} from '../matcher.js'
-import * as rules from '../rules.js'
+import {applyRule, canApplyRule} from '../rule'
+import * as rules from '../rule-list'
 
 const applyRuleString = (rule, input) => print(applyRule(rule, parse(input)))
 const canApplyRuleString = (rule, input) => canApplyRule(rule, parse(input))

--- a/lib/__test__/rule.test.js
+++ b/lib/__test__/rule.test.js
@@ -1,0 +1,146 @@
+import assert from 'assert'
+import {parse, print} from 'math-parser'
+import {build, query} from 'math-nodes'
+
+import {defineRule, definePatternRule, canApplyRule, applyRule} from '../rule'
+import {populatePattern, patternToMatchFn} from '../pattern'
+
+
+// returns the rewritten string
+const rewriteString = (matchPattern, rewritePattern, input) => {
+    const rule = defineRuleString(matchPattern, rewritePattern)
+    const ast = applyRule(rule, parse(input))
+    return print(ast)
+}
+
+const defineRuleString = (matchPattern, rewritePattern, constraints) =>
+    definePatternRule(parse(matchPattern), parse(rewritePattern), constraints)
+
+const canApplyRuleString = (rule, input) => canApplyRule(rule, parse(input))
+
+const applyRuleString = (rule, input) => print(applyRule(rule, parse(input)))
+
+const populatePatternString = (pattern, placeholders) => populatePattern(parse(pattern), placeholders)
+
+const isFunction = (val) => typeof val === 'function'
+
+describe('rule functions', () => {
+    describe('rewrite', () => {
+        it('should replace x + 0', () => {
+            const result = rewriteString('#a + 0', '#a', '2 * (x + 0)')
+            assert.equal(result, '2 * x')
+        })
+
+        it('should replace x + 0 as a subexpression', () => {
+            const result = rewriteString('#a + 0', '#a', '2 * (x + 0)')
+            assert.equal(result, '2 * x')
+        })
+
+        it('should replace the innermost x + 0', () => {
+            const result = rewriteString('#a + 0', '#a', '(x + 0) + 0')
+            assert.equal(result, 'x + 0')
+        })
+
+        it('should replace x + 0 within a large expression', () => {
+            const result = rewriteString('#a + 0', '#a', '1 + x + 0 + 2')
+            assert.equal(result, '1 + x + 2')
+        })
+
+        it('should replace an single node with an add operation', () => {
+            const result = rewriteString('2 #a', '#a + #a', '1 + 2 x + 2')
+            assert.equal(result, '1 + (x + x) + 2')
+        })
+
+        it('should replace an single node with a mul operation', () => {
+            const result = rewriteString('2 #a', '#a + #a', '1 * 2 x * 3')
+            assert.equal(result, '1 * (x + x) * 3')
+        })
+
+        it('should work from the inside out', () => {
+            const result = rewriteString('#a + 0', '#a', '((x + 0) + 0) + 0')
+            assert.equal(result, '(x + 0) + 0')
+        })
+
+        it('should apply the rule a single time', () => {
+            const result = rewriteString('#a + 0', '#a', '(x + 0) + (x + 0)')
+            assert.equal(result, 'x + (x + 0)')
+
+            const result2 = rewriteString('#a + 0', '#a', 'x + 0 + x + 0')
+            assert.equal(result2, 'x + x + 0')
+        })
+    })
+
+    describe('canApplyRule', () => {
+        it('should accept applicable rules', () => {
+            const rule = defineRuleString('#a + #a', '2 #a')
+            assert(canApplyRuleString(rule, 'x + x'))
+        })
+
+        it('should reject unapplicable rules', () => {
+            const rule = defineRuleString('#a + #a', '2 #a')
+            assert.equal(canApplyRuleString(rule, 'x + y'), false)
+        })
+
+        it('should accept applicable rules based on constraints', () => {
+            const rule = defineRuleString('#a + #a', '2 * #a', { a: query.isNumber })
+            assert(canApplyRuleString(rule, '3 + 3'))
+        })
+
+        it('should reject unapplicable rules based on constraints', () => {
+            const rule = defineRuleString('#a + #a', '2 #a', { a: query.isNumber })
+            assert.equal(canApplyRuleString(rule, 'x + x'), false)
+        })
+    })
+
+    describe('applyRule', () => {
+        it('should apply applicable rules', () => {
+            const rule = defineRuleString('#a + #a', '2 #a')
+            assert.equal(applyRuleString(rule, 'x + x'), '2 x')
+        })
+
+        it('should apply applicable rules based on constraints', () => {
+            const rule = defineRuleString('#a #x + #b #x', '(#a + #b) #x', {
+                a: query.isNumber,
+                b: query.isNumber,
+            })
+            assert.equal(applyRuleString(rule, '2 x + 3 x'), '(2 + 3) x')
+            assert.equal(canApplyRuleString(rule, '(a + b) x'), false)
+        })
+
+        it('should apply rules with a rewrite callback', () => {
+            const rule = defineRule(
+                patternToMatchFn(parse('#a #b'), {b: query.isAdd}),
+                (_, {a, b}) => build.applyNode(
+                    'add',
+                    b.args.map(arg => populatePatternString('#a #arg', {a, arg}))
+                ),
+                {b: query.isAdd})
+
+            assert.equal(
+                applyRuleString(rule, '3 (x + 1)'),
+                '3 x + 3 1')
+
+            assert.equal(
+                applyRuleString(rule, '(a - b) (x^2 + 2x + 1)'),
+                '(a - b) x^2 + (a - b) (2 x) + (a - b) 1')
+        })
+
+        it('should evaluate sums of numbers', () => {
+            const rule = defineRule(
+                patternToMatchFn(parse('#a'), {
+                    a: (a) => query.isAdd(a) && a.args.every(query.isNumber)
+                }),
+                // TODO: use evaluate from node-parser
+                // TODO: add a special 'eval' node so that we do '#eval(#a)'
+                (_, {a}) => build.numberNode(
+                    a.args.reduce((total, arg) => total + query.getValue(arg), 0)),
+                {
+                    a: (a) => query.isAdd(a) && a.args.every(query.isNumber)
+                },
+            )
+
+            assert.equal(applyRuleString(rule, '(1 - 2 + 3) x'), '2 x')
+            assert.equal(applyRuleString(rule, '(1 + 2 + 3) x'), '6 x')
+        })
+    })
+})

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -3,23 +3,13 @@
  */
 import {build, query} from 'math-nodes'
 import {print} from 'math-parser'
-import evaluate from 'math-evaluator'
 import {replace, traverse} from 'math-traverse'
 
-import {
-    checkBounds,
-    clone,
-    fixMinuses,
-    getPlaceholders,
-    isVariableLengthPattern,
-    removeUnnecessaryParentheses,
-} from './utils'
+import {clone, getPlaceholders, isVariableLengthPattern} from './utils'
 
 const isArray = (val) => Array.isArray(val)
 const isObject = (val) => typeof val === 'object' && val !== null
 const isFunction = (val) => typeof val === 'function'
-
-const isPlaceholder = node => node && node.type === 'Placeholder'
 
 /**
  * Expand a variable length pattern.
@@ -41,7 +31,7 @@ const isPlaceholder = node => node && node.type === 'Placeholder'
  *
  *   #a_0 - #a_1 + #a_2
  */
-const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
+export const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     const firstPattern = pattern.args[0]
     const firstPlaceholders = clone(getPlaceholders(firstPattern))
 
@@ -51,8 +41,8 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     const subscriptCounters = {}
 
     // Variable length patterns can be nested so we need to guard against
-    // expanding them more than once.  For an example, ee COMMON_DENOMINATOR
-    // in rules.js.
+    // expanding them more than once.  For an example, see COMMON_DENOMINATOR
+    // in rule-list.js.
     let skipExpansion = false
 
     for (let i = 0; i < length; i++) {
@@ -390,160 +380,4 @@ export const match = (matchFn, input, constraints = {}) => {
     })
 
     return result
-}
-
-/**
- * Replace any Placeholder nodes in an AST pattern with values from a
- * placeholder dictionary.
- *
- * This handles expansion of variable length patterns.
- */
-export const populatePattern = (pattern, placeholders) => {
-    const expandedPattern = replace(clone(pattern), {
-        enter(node) {
-            if (isVariableLengthPattern(node)) {
-                const firstPattern = node.args[0]
-                const firstPlaceholders = clone(getPlaceholders(firstPattern))
-
-                let variablePlaceholder = null
-                for (const [name, placeholder] of Object.entries(firstPlaceholders)) {
-                    if (placeholder.subscript) {
-                        variablePlaceholder = placeholder
-                        break
-                    }
-                }
-
-                const values = placeholders[variablePlaceholder.name]
-                const length = parseInt(Math.max(...Object.keys(values))) + 1
-
-                return _expandVariableLengthPatternNode(node, length, placeholders.negatives)
-            }
-        }
-    })
-
-    return replace(expandedPattern, {
-        leave(node) {
-            if (node.type === 'Apply' && isPlaceholder(node.op) && node.op.name === 'eval') {
-                return build.numberNode(evaluate(node.args[0]))
-            } else if (node.type === 'Placeholder' && node.name in placeholders) {
-                if (node.subscript) {
-                    const subscript = print(node.subscript)
-                    return clone(placeholders[node.name][subscript])
-                } else {
-                    return clone(placeholders[node.name])
-                }
-            }
-        }
-    })
-}
-
-/**
- * Convert pattern AST to matching function.
- *
- * The resulting function accepts an AST node.  Passing this to 'match' along
- * with the root node of an AST will will return the first node whose subtree
- * matches the structured described in the pattern.
- */
-export const patternToMatchFn = (pattern, constraints) =>
-    node => {
-        const result = matchNode(pattern, node, constraints)
-        if (result) {
-            return {
-                node,
-                ...result,
-            }
-        } else {
-            return null
-        }
-    }
-
-/**
- * Convert pattern AST to a rewrite function.
- *
- * The resulting function will accept an AST node and a placeholders object.
- * The node passed to the function is the matched node returned by 'match' in
- * applyRule.
- */
-export const patternToRewriteFn = pattern =>
-    (node, placeholders) => removeUnnecessaryParentheses(populatePattern(pattern, placeholders))
-
-
-// Public API
-
-/**
- * Define a rewrite rule.
- *
- * While this function provides more flexibility when defining rewrite rules,
- * it's harder to use.  Use definePatternRule whenever possible.
- *
- * @param {Function} matchFn a function taking an AST returning a match result
- * @param {Function} rewriteFn a function taking an AST and placeholders object
- * and returning an updated copy of the AST
- * @param {Object} [constraints] an optional dictionary with placholder names
- * for keys and functions for values.  The functions take an AST node and return
- * a boolean.
- */
-export const defineRule = (matchFn, rewriteFn, constraints = {}) => {
-    return {
-        matchFn,
-        rewriteFn,
-        constraints,
-    }
-}
-
-/**
- * Define a rewrite rule using patterns.
- *
- * @param {node} matchPattern pattern to match
- * @param {node} rewritePattern pattern to output
- * @param {Object} constraints object with placeholder names for keys and
- * functions taking nodes and return booleans as values
- */
-export const definePatternRule = (matchPattern, rewritePattern, constraints = {}) => {
-    // TODO: sanity checking for patterns being passed in
-    // - rewritePattern can't have any Pattern nodes with names not in matchPattern
-    const matchFn = patternToMatchFn(matchPattern, constraints)
-    const rewriteFn = patternToRewriteFn(rewritePattern)
-    return defineRule(matchFn, rewriteFn, constraints)
-}
-
-/**
- * Check if the rule can be applied before actually applying it.
- */
-export const canApplyRule = (rule, node) =>
-    !!match(rule.matchFn, node, rule.constraints)
-
-/**
- * Apply a rule to the given input pattern.
- *
- * Match a single node in input based on matchPattern.  If a match is found,
- * the node will be replaced with the rewritePattern with all of the pattern's
- * placeholder nodes replaced with the placeholder values determined when making
- * the initial match.
- */
-export const applyRule = (rule, input) => {
-    const {matchFn, rewriteFn, constraints} = rule
-    const {node, placeholders, indexes} = match(matchFn, input, constraints)
-    const matchedNode = node
-
-    if (matchedNode) {
-        const replacement = fixMinuses(rewriteFn(matchedNode, placeholders, indexes))
-        return removeUnnecessaryParentheses(replace(input, {
-            leave(node) {
-                if (node === matchedNode) {
-                    if (indexes && checkBounds(indexes, node.args)) {
-
-                        const {start, end} = indexes
-                        // TODO: make running that pass optional so that it
-                        // can be done separately if necessary
-                        node.args.splice(start, end - start, clone(replacement))
-                    } else {
-                        return clone(replacement)
-                    }
-                }
-            }
-        }))
-    } else {
-        return input
-    }
 }

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -84,7 +84,8 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     return expandedPattern
 }
 
-const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
+const _matchPlaceholder = (pattern, input, context) => {
+    const {constraints, placeholders} = context
     const hasConstraint = pattern.name in constraints
     const meetsConstraint = hasConstraint && constraints[pattern.name](input)
 
@@ -96,8 +97,7 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
                 return _matchNode(
                     placeholders[pattern.name][subscript],
                     input,
-                    constraints,
-                    placeholders)
+                    context)
             } else if (placeholders[pattern.name]) {
                 placeholders[pattern.name][subscript] = clone(input)
                 return true
@@ -112,8 +112,7 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
                 return _matchNode(
                     placeholders[pattern.name],
                     input,
-                    constraints,
-                    placeholders)
+                    context)
             } else {
                 placeholders[pattern.name] = clone(input)
                 return true
@@ -125,22 +124,34 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
 
 const _matchEllipsis = (
     pattern,
-    patternIndex,       // index
-
+    patternIndex,
     input,
-    inputIndex,         // j
-    inputIndexOffset,   // i
-
-    constraints, placeholdersCopy, negatives) => {
-
-    const index = patternIndex
-    const i = inputIndexOffset
-    let j = inputIndex
+    inputIndex,
+    context,
+    negatives,
+) => {
 
     const subscriptCounters = {}
-    const previousPattern = pattern.args[index - 1]
-    const k = j
-    while (j < input.args.length) {
+    const previousPattern = pattern.args[patternIndex - 1]
+
+    const matchedArgs = []
+
+    for (let i = inputIndex; i < input.args.length; i++) {
+        let arg = input.args[i]
+
+        if (query.isAdd(pattern)) {
+            if (query.isNeg(arg)) {
+                // Keep track of which items in the expandable part the pattern
+                // are negative.
+                negatives[i] = {wasMinus: arg.wasMinus}
+
+                // If the the pattern is an 'add' then we'll want to unwrap any
+                // 'neg' nodes before matching so that we can match +/- terms
+                // in the same expression.
+                arg = arg.args[0]
+            }
+        }
+
         const currentPattern = replace(
             clone(previousPattern),
             {
@@ -156,43 +167,21 @@ const _matchEllipsis = (
             }
         )
 
-        let arg = input.args[j]
-
-        if (query.isAdd(pattern)) {
-            // Keep track of which items in the expandable part
-            // of the pattern are negative.
-            negatives[j - i] = query.isAdd(pattern) && query.isNeg(arg)
-                ? {wasMinus: arg.wasMinus}
-                : null
-
-            // If the the pattern is an 'add' then we'll want to
-            // unwrap any 'neg' nodes before matching so that we
-            // can match + and - terms in the same expression
-            if (query.isNeg(arg)) {
-                arg = arg.args[0]
-            }
-        }
-
-        if (!_matchNode(
-                currentPattern,
-                arg,
-                constraints,
-                placeholdersCopy)) {
-            break
+        if (_matchNode(currentPattern, arg, context)) {
+            matchedArgs.push(arg)
         } else {
-            j++
+            break
         }
     }
 
     // success if we matched at least one other node in the
     // variable part of the pattern
-    return j - k
+    return matchedArgs.length
 }
 
-const ignoreKeys = ['loc', 'implicit']
+const _matchSubArray = (input, pattern, context, indexes) => {
+    const {constraints, placeholders} = context
 
-
-const _matchSubArray = (input, pattern, placeholders, constraints, indexes) => {
     for (let i = 0; i <= input.args.length - pattern.args.length; i++) {
         // we need to be able to recover from a failed match at for
         // each sub-array so we copy the matched nodes before doing
@@ -201,23 +190,20 @@ const _matchSubArray = (input, pattern, placeholders, constraints, indexes) => {
         const negatives = {}
 
         let j = i
-        const allPatternArgsMatch = pattern.args.every((_, index) => {
+        const allPatternArgsMatch = pattern.args.every((patternArg, patternIndex) => {
             if (j >= input.args.length) {
                 return
             }
 
-            let currentPattern = pattern.args[index]
-            if (currentPattern.type === 'Ellipsis') {
+            const currentContext = {...context, placeholders: placeholdersCopy}
+
+            if (patternArg.type === 'Ellipsis') {
                 const diff = _matchEllipsis(
                     pattern,
-                    index,
-
+                    patternIndex,
                     input,
-                    j,
-                    i,
-
-                    constraints,
-                    placeholdersCopy,
+                    j,  // inputIndex
+                    currentContext,
                     negatives,
                 )
 
@@ -229,10 +215,9 @@ const _matchSubArray = (input, pattern, placeholders, constraints, indexes) => {
                 }
             } else {
                 return _matchNode(
-                    currentPattern,
+                    patternArg,
                     input.args[j++],
-                    constraints,
-                    placeholdersCopy)
+                    currentContext)
             }
         })
 
@@ -275,15 +260,15 @@ const _matchSubArray = (input, pattern, placeholders, constraints, indexes) => {
 const _matchNode = (
     pattern,
     input,
-    constraints = {},
-    placeholders = {},
+    context,
     indexes = {},
 ) => {
     if (pattern.type === 'Placeholder') {
-        return _matchPlaceholder(pattern, input, constraints, placeholders)
+        return _matchPlaceholder(pattern, input, context)
     }
 
     // filter out keys we want to ignore
+    const ignoreKeys = ['loc', 'implicit']
     const patternKeys = Object.keys(pattern).filter(key => !ignoreKeys.includes(key))
     const nodeKeys = Object.keys(input).filter(key => !ignoreKeys.includes(key))
 
@@ -297,15 +282,14 @@ const _matchNode = (
             return _matchSubArray(
                 input,
                 pattern,
-                placeholders,
-                constraints,
-                indexes)
+                context,
+                indexes,
+            )
         } else if (isObject(pattern[key])) {
             return _matchNode(
                 pattern[key],
                 input[key],
-                constraints,
-                placeholders)
+                context)
         } else {
             return pattern[key] === input[key]
         }
@@ -326,8 +310,9 @@ export const matchNode = (
 ) => {
     const placeholders = {}
     const indexes = {}
+    const context = {constraints, placeholders}
 
-    if (_matchNode(pattern, input, constraints, placeholders, indexes)) {
+    if (_matchNode(pattern, input, context, indexes)) {
         return {placeholders, indexes}
     } else {
         return null

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -21,9 +21,26 @@ const isFunction = (val) => typeof val === 'function'
 
 const isPlaceholder = node => node && node.type === 'Placeholder'
 
-// TODO: handle reverse variable length patterns, e.g.
-// ... + #a_0
-
+/**
+ * Expand a variable length pattern.
+ *
+ * Examples:
+ *   #a_0 + ... -> #a_0 + #a_1 + #a_2 (length = 3)
+ *   #b_0 * ... -> #b_0 * #b_1 * #b_2 * #b_4 (length = 4)
+ *
+ * Since 'add' nodes can contain a mix of positive and negative numbers, some
+ * of which may have been minuses when they were parse, this function takes an
+ * optional 'negatives' array which describes which nodes should be separated
+ * by minus signs, e.g.
+ *
+ *   pattern: #a_0 + ...
+ *   length: 3
+ *   negatives: [null, {wasMinus: true}, null]
+ *
+ * will result in
+ *
+ *   #a_0 - #a_1 + #a_2
+ */
 const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     const firstPattern = pattern.args[0]
     const firstPlaceholders = clone(getPlaceholders(firstPattern))
@@ -33,6 +50,9 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
 
     const subscriptCounters = {}
 
+    // Variable length patterns can be nested so we need to guard against
+    // expanding them more than once.  For an example, ee COMMON_DENOMINATOR
+    // in rules.js.
     let skipExpansion = false
 
     for (let i = 0; i < length; i++) {
@@ -62,6 +82,9 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
                 },
                 leave(node) {
                     if (node.wasExpanded) {
+                        // Reset the skipExpansion flag so that we can continue
+                        // to expand other patterns that might appear in the
+                        // current node.
                         skipExpansion = false
                     }
                 }
@@ -72,6 +95,8 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
 
     expandedPattern.wasExpanded = true
 
+    // Convert any nodes to negatives and set their 'wasMinus' flag based on
+    // the 'negatives' array.
     if (query.isAdd(expandedPattern) && negatives) {
         for (let i = 0; i < expandedPattern.args.length; i++) {
             if (negatives[i]) {
@@ -84,45 +109,67 @@ const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     return expandedPattern
 }
 
+/**
+ * Match a placeholder and enforce constraints.
+ *
+ * The first a placeholder is matched we only verify the constraint for that
+ * placeholder.  We store a copy of the node that was matched and verify all
+ * subsequent attempts to match that placeholder against the stored node.
+ *
+ * When matching placeholders with subscripts, we verify a single constraint
+ * against all placeholders with the same name, e.g. #a_0, #a_1, ... will all
+ * be checked against the constraint 'a' if exists.
+ *
+ * Matched nodes for #a_0, #a_1, ... are stored in an array in placeholders
+ * under the key 'a'.
+ */
 const _matchPlaceholder = (pattern, input, context) => {
     const {constraints, placeholders} = context
     const hasConstraint = pattern.name in constraints
+    const {name} = pattern
     const meetsConstraint = hasConstraint && constraints[pattern.name](input)
 
     if (!hasConstraint || meetsConstraint) {
         if (pattern.subscript) {
             const subscript = print(pattern.subscript)
 
-            if (placeholders[pattern.name] && placeholders[pattern.name][subscript]) {
+            if (placeholders[name] && placeholders[name][subscript]) {
                 return _matchNode(
-                    placeholders[pattern.name][subscript],
+                    placeholders[name][subscript],
                     input,
                     context)
-            } else if (placeholders[pattern.name]) {
-                placeholders[pattern.name][subscript] = clone(input)
+            } else if (placeholders[name]) {
+                placeholders[name][subscript] = clone(input)
                 return true
             } else {
-                placeholders[pattern.name] = {
+                placeholders[name] = {
                     [subscript]: clone(input)
                 }
                 return true
             }
         } else {
-            if (pattern.name in placeholders) {
-                return _matchNode(
-                    placeholders[pattern.name],
-                    input,
-                    context)
+            if (name in placeholders) {
+                return _matchNode(placeholders[name], input, context)
             } else {
-                placeholders[pattern.name] = clone(input)
+                placeholders[name] = clone(input)
                 return true
             }
         }
     }
 }
 
-
-const _matchEllipsis = (
+/**
+ * If an ellipsis follows an argument in an 'add' or 'mul' node that contains
+ * a placeholder with a subscript, then we attempt to match that argument
+ * multiple times, e.g. given:
+ *
+ * pattern: #a_0 / #b_0 + ...
+ * input: 1 + 1/2 + 2/3 + 3/4 + 5
+ *
+ * The function will match 2/3 and 3/4.  It doesn't match the 1/2 because that
+ * was matched by _matchSubArray before this function was called.
+ */
+const _matchExpandableEllipsis = (
     pattern,
     patternIndex,
     input,
@@ -132,7 +179,7 @@ const _matchEllipsis = (
 ) => {
 
     const subscriptCounters = {}
-    const previousPattern = pattern.args[patternIndex - 1]
+    const initialPattern = pattern.args[patternIndex - 1]
 
     const matchedArgs = []
 
@@ -152,8 +199,11 @@ const _matchEllipsis = (
             }
         }
 
+        // Increment subscripts in placeholder nodes by one each time through
+        // this loop, e.g.
+        // #a_0 / #b_0 -> #a_1 / #b_1, #a_2 / #b_2, ...
         const currentPattern = replace(
-            clone(previousPattern),
+            clone(initialPattern),
             {
                 leave(node) {
                     if (node.type === 'Placeholder' && node.subscript) {
@@ -179,6 +229,15 @@ const _matchEllipsis = (
     return matchedArgs.length
 }
 
+/**
+ * Patterns that match 'add' or 'mul' nodes need to match a sub array of args
+ * so that rules like '#a + #b -> #b + #a' can be used in 'add' nodes with
+ * more than two args, e.g. '1 + 2 + 3'.
+ *
+ * This function also handles matching variable length expressions such as
+ * '#a_0 + ...' which can match any number of args within an 'add' node.
+ * See _matchExpandableEllipsis for more information.
+ */
 const _matchSubArray = (input, pattern, context, indexes) => {
     const {constraints, placeholders} = context
 
@@ -198,7 +257,7 @@ const _matchSubArray = (input, pattern, context, indexes) => {
             const currentContext = {...context, placeholders: placeholdersCopy}
 
             if (patternArg.type === 'Ellipsis') {
-                const diff = _matchEllipsis(
+                const diff = _matchExpandableEllipsis(
                     pattern,
                     patternIndex,
                     input,
@@ -214,10 +273,7 @@ const _matchSubArray = (input, pattern, context, indexes) => {
                     return false
                 }
             } else {
-                return _matchNode(
-                    patternArg,
-                    input.args[j++],
-                    currentContext)
+                return _matchNode(patternArg, input.args[j++], currentContext)
             }
         })
 
@@ -381,7 +437,13 @@ export const populatePattern = (pattern, placeholders) => {
     })
 }
 
-
+/**
+ * Convert pattern AST to matching function.
+ *
+ * The resulting function accepts an AST node.  Passing this to 'match' along
+ * with the root node of an AST will will return the first node whose subtree
+ * matches the structured described in the pattern.
+ */
 export const patternToMatchFn = (pattern, constraints) =>
     node => {
         const result = matchNode(pattern, node, constraints)
@@ -395,6 +457,13 @@ export const patternToMatchFn = (pattern, constraints) =>
         }
     }
 
+/**
+ * Convert pattern AST to a rewrite function.
+ *
+ * The resulting function will accept an AST node and a placeholders object.
+ * The node passed to the function is the matched node returned by 'match' in
+ * applyRule.
+ */
 export const patternToRewriteFn = pattern =>
     (node, placeholders) => removeUnnecessaryParentheses(populatePattern(pattern, placeholders))
 

--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -24,7 +24,7 @@ const isPlaceholder = node => node && node.type === 'Placeholder'
 // TODO: handle reverse variable length patterns, e.g.
 // ... + #a_0
 
-const expandVariableLengthPatternNode = (pattern, length, negatives) => {
+const _expandVariableLengthPatternNode = (pattern, length, negatives) => {
     const firstPattern = pattern.args[0]
     const firstPlaceholders = clone(getPlaceholders(firstPattern))
 
@@ -47,7 +47,7 @@ const expandVariableLengthPatternNode = (pattern, length, negatives) => {
                     if (node.wasExpanded) {
                         skipExpansion = true
                     } else if (isVariableLengthPattern(node)) {
-                        const result = expandVariableLengthPatternNode(node, length, negatives)
+                        const result = _expandVariableLengthPatternNode(node, length, negatives)
                         if (result.wasExpanded) {
                             skipExpansion = true
                         }
@@ -95,7 +95,6 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
             if (placeholders[pattern.name] && placeholders[pattern.name][subscript]) {
                 return _matchNode(
                     placeholders[pattern.name][subscript],
-                    pattern, // parent
                     input,
                     constraints,
                     placeholders)
@@ -112,7 +111,6 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
             if (pattern.name in placeholders) {
                 return _matchNode(
                     placeholders[pattern.name],
-                    pattern, // parent
                     input,
                     constraints,
                     placeholders)
@@ -124,7 +122,141 @@ const _matchPlaceholder = (pattern, input, constraints, placeholders) => {
     }
 }
 
+
+const _matchEllipsis = (
+    pattern,
+    patternIndex,       // index
+
+    input,
+    inputIndex,         // j
+    inputIndexOffset,   // i
+
+    constraints, placeholdersCopy, negatives) => {
+
+    const index = patternIndex
+    const i = inputIndexOffset
+    let j = inputIndex
+
+    const subscriptCounters = {}
+    const previousPattern = pattern.args[index - 1]
+    const k = j
+    while (j < input.args.length) {
+        const currentPattern = replace(
+            clone(previousPattern),
+            {
+                leave(node) {
+                    if (node.type === 'Placeholder' && node.subscript) {
+                        const name = node.name
+                        if (!subscriptCounters.hasOwnProperty(name)) {
+                            subscriptCounters[name] = 1
+                        }
+                        node.subscript.value = String(subscriptCounters[name]++)
+                    }
+                }
+            }
+        )
+
+        let arg = input.args[j]
+
+        if (query.isAdd(pattern)) {
+            // Keep track of which items in the expandable part
+            // of the pattern are negative.
+            negatives[j - i] = query.isAdd(pattern) && query.isNeg(arg)
+                ? {wasMinus: arg.wasMinus}
+                : null
+
+            // If the the pattern is an 'add' then we'll want to
+            // unwrap any 'neg' nodes before matching so that we
+            // can match + and - terms in the same expression
+            if (query.isNeg(arg)) {
+                arg = arg.args[0]
+            }
+        }
+
+        if (!_matchNode(
+                currentPattern,
+                arg,
+                constraints,
+                placeholdersCopy)) {
+            break
+        } else {
+            j++
+        }
+    }
+
+    // success if we matched at least one other node in the
+    // variable part of the pattern
+    return j - k
+}
+
 const ignoreKeys = ['loc', 'implicit']
+
+
+const _matchSubArray = (input, pattern, placeholders, constraints, indexes) => {
+    for (let i = 0; i <= input.args.length - pattern.args.length; i++) {
+        // we need to be able to recover from a failed match at for
+        // each sub-array so we copy the matched nodes before doing
+        // the comparison.
+        const placeholdersCopy = {...placeholders}
+        const negatives = {}
+
+        let j = i
+        const allPatternArgsMatch = pattern.args.every((_, index) => {
+            if (j >= input.args.length) {
+                return
+            }
+
+            let currentPattern = pattern.args[index]
+            if (currentPattern.type === 'Ellipsis') {
+                const diff = _matchEllipsis(
+                    pattern,
+                    index,
+
+                    input,
+                    j,
+                    i,
+
+                    constraints,
+                    placeholdersCopy,
+                    negatives,
+                )
+
+                if (diff > 0) {
+                    j += diff
+                    return true
+                } else {
+                    return false
+                }
+            } else {
+                return _matchNode(
+                    currentPattern,
+                    input.args[j++],
+                    constraints,
+                    placeholdersCopy)
+            }
+        })
+
+        if (allPatternArgsMatch) {
+            indexes.start = i
+            indexes.end = j
+
+            // matchNodesCopy may have been updated to copy over any
+            // new entries to matchedNodes
+            Object.assign(placeholders, placeholdersCopy)
+
+            // TODO: find a better place to put this
+            // If there are negatives that need to be tracked at
+            // different levels in the pattern then this approach isn't
+            // robust enough.
+            if (Object.keys(negatives).length > 0) {
+                placeholders.negatives = negatives
+            }
+
+            return true
+        }
+    }
+    return false
+}
 
 /**
  * Match input node with pattern node.
@@ -142,7 +274,6 @@ const ignoreKeys = ['loc', 'implicit']
  */
 const _matchNode = (
     pattern,
-    patternParent,
     input,
     constraints = {},
     placeholders = {},
@@ -163,106 +294,15 @@ const _matchNode = (
     // all keys must match
     return patternKeys.every(key => {
         if (key === 'args' && (query.isMul(pattern) && query.isMul(input) || query.isAdd(pattern) && query.isAdd(input))) {
-            for (let i = 0; i <= input.args.length - pattern.args.length; i++) {
-                // we need to be able to recover from a failed match at for
-                // each sub-array so we copy the matched nodes before doing
-                // the comparison.
-                const placeholdersCopy = {...placeholders}
-                const negatives = {}
-
-                let j = i
-                const allArgsMatch = pattern.args.every((_, index) => {
-                    if (j >= input.args.length) {
-                        return
-                    }
-
-                    let currentPattern = pattern.args[index]
-                    if (currentPattern.type === 'Ellipsis') {
-                        const subscriptCounters = {}
-                        const previousPattern = pattern.args[index - 1]
-                        const k = j
-                        while (j < input.args.length) {
-                            currentPattern = replace(
-                                clone(previousPattern),
-                                {
-                                    leave(node) {
-                                        if (node.type === 'Placeholder' && node.subscript) {
-                                            const name = node.name
-                                            if (!subscriptCounters.hasOwnProperty(name)) {
-                                                subscriptCounters[name] = 1
-                                            }
-                                            node.subscript.value = String(subscriptCounters[name]++)
-                                        }
-                                    }
-                                }
-                            )
-
-                            let arg = input.args[j]
-
-                            if (query.isAdd(pattern)) {
-                                // Keep track of which items in the expandable part
-                                // of the pattern are negative.
-                                negatives[j - i] = query.isAdd(pattern) && query.isNeg(arg)
-                                    ? {wasMinus: arg.wasMinus}
-                                    : null
-
-                                // If the the pattern is an 'add' then we'll want to
-                                // unwrap any 'neg' nodes before matching so that we
-                                // can match + and - terms in the same expression
-                                if (query.isNeg(arg)) {
-                                    arg = arg.args[0]
-                                }
-                            }
-
-                            if (!_matchNode(
-                                currentPattern,
-                                pattern, // parent
-                                arg,
-                                constraints,
-                                placeholdersCopy)) {
-                                break
-                            } else {
-                                j++
-                            }
-                        }
-
-                        // success if we matched at least one other node in the
-                        // variable part of the pattern
-                        return j > k
-                    } else {
-                        return _matchNode(
-                            currentPattern,
-                            pattern, // parent
-                            input.args[j++],
-                            constraints,
-                            placeholdersCopy)
-                    }
-                })
-
-                if (allArgsMatch) {
-                    indexes.start = i
-                    indexes.end = j
-
-                    // matchNodesCopy may have been updated to copy over any
-                    // new entries to matchedNodes
-                    Object.assign(placeholders, placeholdersCopy)
-
-                    // TODO: find a better place to put this
-                    // If there are negatives that need to be tracked at
-                    // different levels in the pattern then this approach isn't
-                    // robust enough.
-                    if (Object.keys(negatives).length > 0) {
-                        placeholders.negatives = negatives
-                    }
-
-                    return true
-                }
-            }
-            return false
+            return _matchSubArray(
+                input,
+                pattern,
+                placeholders,
+                constraints,
+                indexes)
         } else if (isObject(pattern[key])) {
             return _matchNode(
                 pattern[key],
-                pattern, // parent
                 input[key],
                 constraints,
                 placeholders)
@@ -287,7 +327,7 @@ export const matchNode = (
     const placeholders = {}
     const indexes = {}
 
-    if (_matchNode(pattern, null, input, constraints, placeholders, indexes)) {
+    if (_matchNode(pattern, input, constraints, placeholders, indexes)) {
         return {placeholders, indexes}
     } else {
         return null
@@ -335,7 +375,7 @@ export const populatePattern = (pattern, placeholders) => {
                 const values = placeholders[variablePlaceholder.name]
                 const length = parseInt(Math.max(...Object.keys(values))) + 1
 
-                return expandVariableLengthPatternNode(node, length, placeholders.negatives)
+                return _expandVariableLengthPatternNode(node, length, placeholders.negatives)
             }
         }
     })

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -1,0 +1,84 @@
+import evaluate from 'math-evaluator'
+import {build, query} from 'math-nodes'
+import {print} from 'math-parser'
+import {replace, traverse} from 'math-traverse'
+
+import {matchNode, _expandVariableLengthPatternNode} from './matcher'
+import {clone, isVariableLengthPattern, removeUnnecessaryParentheses, getPlaceholders} from './utils'
+
+const isPlaceholder = node => node && node.type === 'Placeholder'
+
+/**
+ * Replace any Placeholder nodes in an AST pattern with values from a
+ * placeholder dictionary.
+ *
+ * This handles expansion of variable length patterns.
+ */
+export const populatePattern = (pattern, placeholders) => {
+    const expandedPattern = replace(clone(pattern), {
+        enter(node) {
+            if (isVariableLengthPattern(node)) {
+                const firstPattern = node.args[0]
+                const firstPlaceholders = clone(getPlaceholders(firstPattern))
+
+                let variablePlaceholder = null
+                for (const [name, placeholder] of Object.entries(firstPlaceholders)) {
+                    if (placeholder.subscript) {
+                        variablePlaceholder = placeholder
+                        break
+                    }
+                }
+
+                const values = placeholders[variablePlaceholder.name]
+                const length = parseInt(Math.max(...Object.keys(values))) + 1
+
+                return _expandVariableLengthPatternNode(node, length, placeholders.negatives)
+            }
+        }
+    })
+
+    return replace(expandedPattern, {
+        leave(node) {
+            if (node.type === 'Apply' && isPlaceholder(node.op) && node.op.name === 'eval') {
+                return build.numberNode(evaluate(node.args[0]))
+            } else if (node.type === 'Placeholder' && node.name in placeholders) {
+                if (node.subscript) {
+                    const subscript = print(node.subscript)
+                    return clone(placeholders[node.name][subscript])
+                } else {
+                    return clone(placeholders[node.name])
+                }
+            }
+        }
+    })
+}
+
+/**
+ * Convert pattern AST to matching function.
+ *
+ * The resulting function accepts an AST node.  Passing this to 'match' along
+ * with the root node of an AST will will return the first node whose subtree
+ * matches the structured described in the pattern.
+ */
+export const patternToMatchFn = (pattern, constraints) =>
+    node => {
+        const result = matchNode(pattern, node, constraints)
+        if (result) {
+            return {
+                node,
+                ...result,
+            }
+        } else {
+            return null
+        }
+    }
+
+/**
+ * Convert pattern AST to a rewrite function.
+ *
+ * The resulting function will accept an AST node and a placeholders object.
+ * The node passed to the function is the matched node returned by 'match' in
+ * applyRule.
+ */
+export const patternToRewriteFn = pattern =>
+    (node, placeholders) => removeUnnecessaryParentheses(populatePattern(pattern, placeholders))

--- a/lib/rule-list.js
+++ b/lib/rule-list.js
@@ -4,7 +4,7 @@ import {gcd, lcm, nthRoot, primeFactorization, abs} from 'math-evaluator'
 import {build, query} from 'math-nodes'
 import {traverse} from 'math-traverse'
 
-import {defineRule, definePatternRule, applyRule, canApplyRule} from './matcher'
+import {defineRule, definePatternRule, applyRule, canApplyRule} from './rule'
 import {isPolynomialTerm, getCoefficient, getVariableFactors} from './rules/collect-like-terms.js'
 import {clone, getRanges} from './utils'
 

--- a/lib/rule.js
+++ b/lib/rule.js
@@ -1,0 +1,84 @@
+import {replace, traverse} from 'math-traverse'
+
+import {patternToMatchFn, patternToRewriteFn} from './pattern'
+import {match} from './matcher'
+import {checkBounds, clone, fixMinuses, removeUnnecessaryParentheses} from './utils'
+
+/**
+ * Define a rewrite rule.
+ *
+ * While this function provides more flexibility when defining rewrite rules,
+ * it's harder to use.  Use definePatternRule whenever possible.
+ *
+ * @param {Function} matchFn a function taking an AST returning a match result
+ * @param {Function} rewriteFn a function taking an AST and placeholders object
+ * and returning an updated copy of the AST
+ * @param {Object} [constraints] an optional dictionary with placholder names
+ * for keys and functions for values.  The functions take an AST node and return
+ * a boolean.
+ */
+export const defineRule = (matchFn, rewriteFn, constraints = {}) => {
+    return {
+        matchFn,
+        rewriteFn,
+        constraints,
+    }
+}
+
+/**
+ * Define a rewrite rule using patterns.
+ *
+ * @param {node} matchPattern pattern to match
+ * @param {node} rewritePattern pattern to output
+ * @param {Object} constraints object with placeholder names for keys and
+ * functions taking nodes and return booleans as values
+ */
+export const definePatternRule = (matchPattern, rewritePattern, constraints = {}) => {
+    // TODO: sanity checking for patterns being passed in
+    // - rewritePattern can't have any Pattern nodes with names not in matchPattern
+    const matchFn = patternToMatchFn(matchPattern, constraints)
+    const rewriteFn = patternToRewriteFn(rewritePattern)
+    return defineRule(matchFn, rewriteFn, constraints)
+}
+
+/**
+ * Check if the rule can be applied before actually applying it.
+ */
+export const canApplyRule = (rule, node) => {
+    return !!match(rule.matchFn, node, rule.constraints)
+}
+
+/**
+ * Apply a rule to the given input pattern.
+ *
+ * Match a single node in input based on matchPattern.  If a match is found,
+ * the node will be replaced with the rewritePattern with all of the pattern's
+ * placeholder nodes replaced with the placeholder values determined when making
+ * the initial match.
+ */
+export const applyRule = (rule, input) => {
+    const {matchFn, rewriteFn, constraints} = rule
+    const {node, placeholders, indexes} = match(matchFn, input, constraints)
+    const matchedNode = node
+
+    if (matchedNode) {
+        const replacement = fixMinuses(rewriteFn(matchedNode, placeholders, indexes))
+        return removeUnnecessaryParentheses(replace(input, {
+            leave(node) {
+                if (node === matchedNode) {
+                    if (indexes && checkBounds(indexes, node.args)) {
+
+                        const {start, end} = indexes
+                        // TODO: make running that pass optional so that it
+                        // can be done separately if necessary
+                        node.args.splice(start, end - start, clone(replacement))
+                    } else {
+                        return clone(replacement)
+                    }
+                }
+            }
+        }))
+    } else {
+        return input
+    }
+}

--- a/lib/rules/collect-like-terms.js
+++ b/lib/rules/collect-like-terms.js
@@ -1,7 +1,8 @@
 import {parse, print} from 'math-parser'
 import {build, query} from 'math-nodes'
 
-import {canApplyRule, defineRule, populatePattern} from '../matcher'
+import {canApplyRule, defineRule} from '../rule'
+import {populatePattern} from '../pattern'
 import {flattenOperands} from '../utils'
 
 const clone = node => JSON.parse(JSON.stringify(node))

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,31 +203,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-generator "^6.24.1"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
-    convert-source-map "^1.1.0"
-    debug "^2.1.1"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    minimatch "^3.0.2"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-core@^6.25.0:
+babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -260,20 +236,7 @@ babel-eslint@^7.2.3:
     babel-types "^6.23.0"
     babylon "^6.17.0"
 
-babel-generator@^6.18.0, babel-generator@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-babel-generator@^6.25.0:
+babel-generator@^6.18.0, babel-generator@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
   dependencies:
@@ -655,17 +618,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.25.0:
+babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
   dependencies:
@@ -675,21 +628,7 @@ babel-template@^6.25.0:
     babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.25.0:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -703,16 +642,7 @@ babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.25.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -721,11 +651,7 @@ babel-types@^6.25.0:
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0, babylon@^6.17.0:
-  version "6.17.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
-
-babylon@^6.17.2:
+babylon@^6.13.0, babylon@^6.17.0, babylon@^6.17.2:
   version "6.17.3"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
@@ -2453,9 +2379,13 @@ math-evaluator@^0.0.9:
   dependencies:
     babel-loader "^7.0.0"
 
-math-nodes@^0.1.2, math-nodes@^0.1.5:
+math-nodes@^0.1.2:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/math-nodes/-/math-nodes-0.1.5.tgz#dfd25c7a9458b91413288ebfcf525cd3a80af6c7"
+
+math-nodes@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/math-nodes/-/math-nodes-0.1.6.tgz#ac38eba233d24c7d3094a0e99035054e55058167"
 
 math-parser@^0.10.4:
   version "0.10.4"


### PR DESCRIPTION
- [x] remove `parentPattern` as it wasn't being used
- [x] extract _matchSubArray and _matchEllipsis from _matchNode
- [x] combine `constraints`, `placeholders` and ~`indexes`~ into a single `context` variable
- [x] add comments
- [x] extract non-match functions such as applyRule, defineRule, etc. from matcher.js into a new file